### PR TITLE
Fix typo in README for third_party/rules_cuda

### DIFF
--- a/third_party/rules_cuda/README.md
+++ b/third_party/rules_cuda/README.md
@@ -27,7 +27,7 @@ http_archive(
     strip_prefix = "runtime-b1c7cce21ba4661c17ac72421c6a0e2015e7bef3/third_party/rules_cuda",
     urls = ["https://github.com/tensorflow/runtime/archive/b1c7cce21ba4661c17ac72421c6a0e2015e7bef3.tar.gz"],
 )
-load("//cuda:dependencies.bzl", "rules_cuda_dependencies")
+load("@rules_cuda//cuda:dependencies.bzl", "rules_cuda_dependencies")
 rules_cuda_dependencies()
 load("@rules_cc//cc:repositories.bzl", "rules_cc_toolchains")
 rules_cc_toolchains()


### PR DESCRIPTION
Fixes a small typo in the readme.